### PR TITLE
Example of customising default cpb location

### DIFF
--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -92,3 +92,8 @@ dependencies {
 tasks.named('jar', Jar) {
     archiveBaseName = 'corda5-solar-system-contracts-demo-workflows'
 }
+
+cpb {
+    archiveBaseName = 'corda5-solar-system'
+    destinationDir = file("$rootDir/build/")
+}


### PR DESCRIPTION
There seems to be some confusion about the cpk/cpb plugins
The cpb only needs to be applied to the "main" module. Because the workflow module speficies a dependency on the contracts module, it will automatically bundle both CPKs. 
The example here places this cpb in the project "root" build folder.